### PR TITLE
fix: 搬动移至图像外，再回到画布跟随鼠标问题

### DIFF
--- a/src/mxreality.js
+++ b/src/mxreality.js
@@ -2011,6 +2011,7 @@
                     }
                 }, false);
                 this.domElement.addEventListener("mouseup", mouseup, false);
+		this.domElement.addEventListener("mouseleave", mouseup, false);
                 this.domElement.addEventListener('touchstart', touchstart, false);
                 this.domElement.addEventListener('touchend', touchend, false);
                 this.domElement.addEventListener('touchmove', touchmove, false);


### PR DESCRIPTION
pc端操作：画面非全屏，鼠标搬动时移到画面外，再回到画面区域时画面跟随鼠标移动问题